### PR TITLE
Create a symlink to libnymphrpc.so.<version>

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,6 +63,7 @@ lib/$(OUTPUT).a: $(OBJECTS)
 	
 lib/$(OUTPUT).so.$(VERSION): $(SHARED_OBJECTS)
 	$(GCC) -o $@ $(CFLAGS) $(SHARED_FLAGS) $(SHARED_OBJECTS) $(LIBS)
+	@ln -s $@ $(OUTPUT).so
 	
 makedir:
 	$(MAKEDIR) lib


### PR DESCRIPTION
This way distributions that split out a -dev package don't have to manually do this and specify a which will change over time