### PR TITLE
Fix the library symlink by changing the directory to lib/ first

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ lib/$(OUTPUT).a: $(OBJECTS)
 	
 lib/$(OUTPUT).so.$(VERSION): $(SHARED_OBJECTS)
 	$(GCC) -o $@ $(CFLAGS) $(SHARED_FLAGS) $(SHARED_OBJECTS) $(LIBS)
-	@ln -s $@ $(OUTPUT).so
+	chdir lib; ln -s $(OUTPUT).so.$(VERSION) $(OUTPUT).so
 	
 makedir:
 	$(MAKEDIR) lib


### PR DESCRIPTION
The symlink has to be made in the same directory, otherwise it's faulty, derp.