### PR TITLE
Add an install target to the Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,6 @@ lib/$(OUTPUT).a: $(OBJECTS)
 	
 lib/$(OUTPUT).so.$(VERSION): $(SHARED_OBJECTS)
 	$(GCC) -o $@ $(CFLAGS) $(SHARED_FLAGS) $(SHARED_OBJECTS) $(LIBS)
-	cd lib && ln -s $(OUTPUT).so.$(VERSION) $(OUTPUT).so
 	
 makedir:
 	$(MAKEDIR) lib
@@ -90,4 +89,21 @@ clean-test-client:
 	
 clean-test-server:
 	$(MAKE) -C ./test/nymph_test_server clean
-	
+
+ifeq ($(PREFIX),)
+	PREFIX := /usr/local
+endif
+
+.PHONY: install
+install:
+	install -d $(DESTDIR)$(PREFIX)/lib/
+	install -m 644 lib/$(OUTPUT).a $(DESTDIR)$(PREFIX)/lib/
+	install -m 644 lib/$(OUTPUT).so.$(VERSION) $(DESTDIR)$(PREFIX)/lib/
+	install -d $(DESTDIR)$(PREFIX)/include/nymph
+	install -m 644 src/*.h $(DESTDIR)$(PREFIX)/include/nymph/
+	cd $(DESTDIR)$(PREFIX)/lib && \
+		if [ -f $(OUTPUT).so ]; then \
+			rm $(OUTPUT).so; \
+		fi && \
+		ln -s $(OUTPUT).so.$(VERSION) $(OUTPUT).so
+


### PR DESCRIPTION
Linux only for now, I don't have a Windows system to test these things on.

Once this is merged, I'd like to do the same for NymphCast. However I wonder how to handle the systemd vs OpenRC init files there...