### PR TITLE
Fix file installation on macOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -220,17 +220,29 @@ install:
 	install -d $(DESTDIR)$(PREFIX)/lib/
 	install -m 644 lib/$(ARCH)$(OUTPUT).a $(DESTDIR)$(PREFIX)$(DEVFOLDER)/lib/
 ifndef OS
+ifeq ($(shell uname -s),Darwin)
+	install -m 644 lib/$(ARCH)$(OUTPUT).0.dylib $(DESTDIR)$(PREFIX)/lib/
+else
 	install -m 644 lib/$(ARCH)$(OUTPUT).so.$(VERSION) $(DESTDIR)$(PREFIX)/lib/
+endif
 endif
 	install -d $(DESTDIR)$(PREFIX)$(DEVFOLDER)/include/nymph
 	install -m 644 src/*.h $(DESTDIR)$(PREFIX)$(DEVFOLDER)/include/nymph/
 
 ifndef OS
+ifeq ($(shell uname -s),Darwin)
+	cd $(DESTDIR)$(PREFIX)/lib && \
+		if [ -f $(OUTPUT).dylib ]; then \
+			rm $(OUTPUT).dylib; \
+		fi && \
+		ln -s $(OUTPUT).0.dylib $(OUTPUT).dylib
+else
 	cd $(DESTDIR)$(PREFIX)/lib && \
 		if [ -f $(OUTPUT).so ]; then \
 			rm $(OUTPUT).so; \
 		fi && \
 		ln -s $(OUTPUT).so.$(VERSION) $(OUTPUT).so
+endif
 endif
 
 package:


### PR DESCRIPTION
I had trouble pointing the linker to where Poco is installed so I manually edited the Makefile for that locally (I'd love pointers to do that with environment variables or something instead, `LDFLAGS` doesn't seem to do it for me although `CXXFLAGS` works for pointing it to the include directory), but otherwise this makes it install everything properly on macOS.